### PR TITLE
CICD: docker compose 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+target/
+.git/
+.idea/
+
+*.md
+.env
+compose.yaml
+compose.prod.yaml
+mvnw
+mvnw.cmd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM maven:3.9-eclipse-temurin-21 AS build
+
+WORKDIR /app
+
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+COPY src/main ./src/main
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+COPY --from=build /app/target/*.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,57 @@
+# я запускаюсь через "docker compose -f compose.prod.yaml up"
+# я выключаюсь через "docker compose -f compose.prod.yaml down"
+
+services:
+  tms-db:
+    image: postgres:16-alpine
+    container_name: tms-db
+    restart: always
+    env_file:
+      - .env
+    ports:
+      - "5432:5432"
+    networks:
+      - tms-network
+    volumes:
+      - tms_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  tms-back:
+    build: .
+    container_name: tms-back
+    restart: always
+    depends_on:
+      tms-db:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    networks:
+      - tms-network
+    env_file:
+      - .env
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://tms-db:5432/${POSTGRES_DB}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+networks:
+  tms-network:
+    name: tms-network
+    driver: bridge
+
+volumes:
+  tms_pgdata:
+    name: tms-pgdata
+    driver: local

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,11 @@ services:
       - "5432:5432"
     volumes:
       - tms_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
Два варианта запуска:
- стандартный через IDEA - поднимется только контейнер бд
- запуск через `docker compose -f compose.prod.yaml up` - поднимется в сети 2 контейнера: бэк и бд